### PR TITLE
chore(version): 1.21

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     implementation("net.kyori:adventure-api:4.17.0")
     api(libs.org.jetbrains.kotlin.kotlin.stdlib.jdk8)
     testImplementation(libs.org.jetbrains.kotlin.kotlin.test)
-    compileOnly("io.papermc.paper:paper-api:1.20.6-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21-R0.1-SNAPSHOT")
     implementation(kotlin("stdlib-jdk8"))
 }
 

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -1,7 +1,7 @@
 name: uwuJobs
 version: '2024.615.0'
 main: me.yellowbear.uwujobs.UwuJobs
-api-version: '1.20'
+api-version: '1.21'
 folia-supported: true
 authors: [yellowbear, mapetr]
 website: https://xdd.moe/


### PR DESCRIPTION
* build against version 1.21 of Paper API
* change the plugin version to 1.21
closes #87 